### PR TITLE
Develop

### DIFF
--- a/src/ASTFinder.js
+++ b/src/ASTFinder.js
@@ -12,9 +12,10 @@ ASTFinder.prototype = {
 		var computeds, expressions, objects;
 		var ast = this.astBuilder.ast(exp);
 
-		this.objects      = objects = {};
-		this.computeds    = computeds = {};
-		this.expressions  = expressions = {};
+    this.objects      = objects = {};
+    this.computeds    = computeds = {};
+    this.expressions  = expressions = {};
+    this.identifiers  = [];
 
 		this.recurse(ast);
 

--- a/src/ASTFinder.js
+++ b/src/ASTFinder.js
@@ -96,7 +96,9 @@ ASTFinder.prototype = {
 	},
 
 	parseIdentifier: function(ast, id, recursion) {
+    this.identifiers.push(ast.name);
 		this.expressions[id].push(ast.name);
+
 		recursion(id);
 	},
 

--- a/src/ASTFinder.js
+++ b/src/ASTFinder.js
@@ -39,7 +39,7 @@ ASTFinder.prototype = {
 			return exp;
 		});
 
-		return this.expressions;
+		return (this.allExps = values(this.expressions));
 	},
 
 	parseProgram: function(ast) {

--- a/src/NodeLink.js
+++ b/src/NodeLink.js
@@ -303,6 +303,13 @@ NodeLink.prototype = {
 					};
 
 					scope.watch(attrs[attrName], parentWatcher);
+
+          // When the property gets changed in the
+          // destination scope, the parent scope gets
+          // updated with the new value, as it should
+          dest.watch(key, function(value) {
+            parentWatcher(get(scope, attrs[attrName]));
+          });
 					break;
 			}
 		}, this);

--- a/src/Scope.js
+++ b/src/Scope.js
@@ -26,26 +26,12 @@ inherits(Scope, Watcher, {
 			child = new this.ChildScopeClass();
 		}
 
-    var childScopes = this.childScopes,
-        lastChildScopeIndex = childScopes.length - 1,
-        nextChildScopeIndex = childScopes.length + 1;
+    var childScopeIndex = this.childScopes.length;
 
-    if(childScopes.length) {
-      childScopes[lastChildScopeIndex].nextSibling = child;
-    }
-
-		childScopes[nextChildScopeIndex] = child;
+		this.childScopes[childScopeIndex] = child;
 
     child.on('destroy', function() {
-      var index = childScopes.length;
-
-      while(index--) {
-        if(childScopes[index] == child) {
-          childScopes.splice(index, 1);
-
-          break;
-        }
-      }
+      this.parentScope.childScopes.splice(childScopeIndex, 1);
     });
 
 		return child;

--- a/src/Scope.js
+++ b/src/Scope.js
@@ -51,6 +51,14 @@ inherits(Scope, Watcher, {
 		return child;
 	},
 
+  broadcast: function(name, fn) {
+    if(this.parentScope) {
+      this.parentScope.broadcast(name, fn);
+    }
+
+    this.emit(name, fn);
+  },
+
 	deliverChangeRecords: function() {
     if(this.parentScope) {
       this.parentScope.deliverChangeRecords();

--- a/src/Watcher.js
+++ b/src/Watcher.js
@@ -26,7 +26,7 @@ inherits(Watcher, EventEmitter, {
 			firstListener = true;
 		}
 
-		this.observer.watch(exp, listener);
+		this.observer.watch(exp, bind(listener, this));
 
 		if(firstListener) {
 			this.observer.fire(exp);

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -370,12 +370,8 @@ function last(array) {
 }
 
 function bind(callback, context) {
-	var args = toArray(arguments).slice(1);
-
 	return function() {
-		args = args.concat(toArray(arguments));
-
-		return callback.apply(args[0], args.slice(1));
+		return callback.apply(context, arguments);
 	};
 }
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -325,6 +325,25 @@ function forEach (array, iterator, context) {
 	return array;
 }
 
+function map (array, iterator, context) {
+  var i,
+      cloned = isArray(array) ? [] : {};
+
+  if(isArray(array)) {
+    for(i = 0; i < array.length; i++) {
+      cloned[i] = iterator.call(context, array[i], i, array);
+    }
+  } else if (isObject(array)) {
+    var keys = Object.keys(array);
+
+    for(i = 0; i < keys.length; i++) {
+      cloned[keys[i]] = iterator.call(context, array[keys[i]], keys[i], array);
+    }
+  }
+
+  return cloned;
+}
+
 function camelCase (str) {
 	return (str = str.replace(/[^A-z]/g, ' ')) && lowercase(str).replace(/(?:^\w|[A-Z]|\b\w|\s+)/g, function(match, index) {
 		if (+match === 0) return ""; // or if (/\s+/.test(match)) for white spaces

--- a/test/AST.js
+++ b/test/AST.js
@@ -20,6 +20,27 @@ describe('AST', function() {
 		});
 	});
 
+  it('should compile assignment expressions', function() {
+    expect(ast.ast('a = 1;')).toEqual({
+      "type": "Program",
+      "body": [{
+        "type": "ExpressionStatement",
+        "expression": {
+          "type": "AssignmentExpression",
+          "operator": "=",
+          "left": {
+            "type": "Identifier",
+            "name": "a"
+          },
+          "right": {
+            "type": "Literal",
+            "value": '1'
+          }
+        }
+      }]
+    });
+  });
+
 	it('should compile a simple expression', function() {
 		expect(ast.ast('a.b.c.d')).toEqual({
 	    "type": "Program",

--- a/test/ASTFinder.js
+++ b/test/ASTFinder.js
@@ -1,0 +1,25 @@
+describe('ASTFinder', function() {
+  var ast,
+      lexer,
+      astFinder;
+
+  beforeEach(function() {
+    lexer = new Lexer();
+    ast = new AST(lexer);
+    astFinder = new ASTFinder(ast);
+  });
+
+  it('should find expressions in simple computed expressions', function() {
+    expect(astFinder.find('a.b.c[d[e.f.g[h]]]')).toEqual([
+      ['d'],
+      ['e', 'f', 'g'],
+      ['h']
+    ]);
+
+    expect(astFinder.find('isUserActive && callMeExpression() && users[index]') && astFinder.identifiers).toEqual([
+      'isUserActive',
+      'users',
+      'index'
+    ]);
+  });
+});

--- a/test/Compile.js
+++ b/test/Compile.js
@@ -242,6 +242,18 @@ describe('Compile', function() {
 						scope.deliverChangeRecords();
 						expect(scope.parentScope.myArrayList).toBe(1);
 
+            scope.inheritance = [];
+            scope.deliverChangeRecords();
+            expect(scope.parentScope.myArrayList).toEqual([]);
+
+            scope.parentScope.myArrayList = null;
+            scope.deliverChangeRecords();
+            expect(scope.inheritance).toBe(null);
+
+            scope.inheritance = [1,2,3,4,5,6];
+            scope.deliverChangeRecords();
+            expect(scope.parentScope.myArrayList).toEqual([1,2,3,4,5,6]);
+
 						scopeSpy();
 					}
 				}

--- a/test/Scope.js
+++ b/test/Scope.js
@@ -44,4 +44,29 @@ describe('Scope', function() {
       expect(child.parentScope).toBe(scope);
     });
   });
+
+  describe('broadcast()', function() {
+    var scope,
+        listenerSpy,
+        deepChildScope;
+
+    beforeEach(function() {
+      scope = new Scope(),
+      listenerSpy = jasmine.createSpy(),
+      deepChildScope = scope;
+
+      for(var i = 0; i < 100; i++) {
+        deepChildScope = deepChildScope.clone();
+      }
+    });
+
+    it('should propagate events through the parents of a scope', function() {
+      scope.on('update', listenerSpy);
+
+      for(var i = 0; i < 10; i++) {
+        deepChildScope.broadcast('update', i);
+        expect(listenerSpy).toHaveBeenCalledWith(i);
+      }
+    });
+  });
 });

--- a/test/Scope.js
+++ b/test/Scope.js
@@ -35,6 +35,32 @@ describe('Scope', function() {
 
       expect(listenerSpy).toHaveBeenCalledWith(1, 0);
     });
+
+  describe('destroy()', function() {
+    var scope,
+        childScope;
+
+    beforeEach(function() {
+      scope = new Scope();
+      childScope = scope.clone();
+    });
+
+    it('should destroy a scope and eliminate all the records of the scope on its parents', function() {
+      for(var i = 0; i < 10; i++) {
+        scope.clone();
+      }
+
+      expect(scope.childScopes.length).toBe(11);
+      expect(scope.childScopes[0]).toBe(childScope);
+
+      childScope.destroy();
+
+      expect(scope.childScopes.length).toBe(10);
+
+      for(var i = 0; i < scope.childScopes.length; i++) {
+        expect(scope.childScopes[i]).not.toBe(childScope);
+      }
+    });
   });
 
   describe('clone()', function() {

--- a/test/Scope.js
+++ b/test/Scope.js
@@ -6,8 +6,13 @@ describe('Scope', function() {
 	});
 
   describe('watch()', function() {
+    var listenerSpy;
+
+    beforeEach(function() {
+      listenerSpy = jasmine.createSpy();
+    });
+
     it('should watch a property', function() {
-      var listenerSpy = jasmine.createSpy();
       scope.watch('someProperty', listenerSpy);
 
       scope.someProperty = 'someValueHere';
@@ -17,20 +22,18 @@ describe('Scope', function() {
     });
 
     it('should deep properties', function() {
-      var watcherSpy = jasmine.createSpy();
-
-      scope.watch('another.deep.property.here', watcherSpy);
+      scope.watch('another.deep.property.here', listenerSpy);
       scope.deliverChangeRecords();
 
       scope.another.deep.property.here = 0;
       scope.deliverChangeRecords();
 
-      expect(watcherSpy).toHaveBeenCalledWith(0, undefined);
+      expect(listenerSpy).toHaveBeenCalledWith(0, undefined);
 
       scope.another.deep.property.here += 1;
       scope.deliverChangeRecords();
 
-      expect(watcherSpy).toHaveBeenCalledWith(1, 0);
+      expect(listenerSpy).toHaveBeenCalledWith(1, 0);
     });
   });
 

--- a/test/Scope.js
+++ b/test/Scope.js
@@ -36,6 +36,31 @@ describe('Scope', function() {
       expect(listenerSpy).toHaveBeenCalledWith(1, 0);
     });
 
+    it('should watch complex expressions', function() {
+      scope.watch('isUserActive && callMeExpression() && users[index]', listenerSpy);
+      scope.deliverChangeRecords();
+
+      expect(listenerSpy).toHaveBeenCalledWith(undefined, undefined);
+
+      scope.isUserActive = true;
+
+      scope.callMeExpression = function() {
+        return true;
+      };
+
+      scope.users = [ 'First user', 'Second user' ];
+      scope.index = 0;
+      scope.deliverChangeRecords();
+
+      expect(listenerSpy).toHaveBeenCalledWith('First user', undefined);
+
+      scope.index++;
+      scope.deliverChangeRecords();
+
+      expect(listenerSpy).toHaveBeenCalledWith('Second user', 'First user');
+    });
+  });
+
   describe('destroy()', function() {
     var scope,
         childScope;


### PR DESCRIPTION
**IMPORTANT**: Scope now accept complex expressions like `a && b() && c() && d + 2 && e`. The ASTFinder will find the expressions that must be are an object and could be watched, and then, the Scope will recompile the entire expression and retrieve a value to the listener everytime each *object* change.