### PR TITLE
chore(src/Scanner.js): it should replace the interpolated attribute w…

### DIFF
--- a/src/Scanner.js
+++ b/src/Scanner.js
@@ -102,6 +102,8 @@ Scanner.prototype = {
 							return;
 						}
 
+            attrs[name] = interpolate.compile(scope);
+
 						scope.watchGroup(interpolate.exps, function() {
 							attrs.$set(name, interpolate.compile(scope));
 						});

--- a/test/Compile.js
+++ b/test/Compile.js
@@ -476,6 +476,47 @@ describe('Compile', function() {
 				'i-just-changed-this-value"></span></div>'
 			);
 		});
+
+    it('should auto compile the interpolated attribute on pre link at priority 100', function() {
+      node = createNode(
+        '<span attribute="{{ someExpHere || 1 }}"></span>'
+      );
+
+      var html = {};
+
+      renderer.register('span', function() {
+        return {
+          compile: function() {
+            return {
+              pre: function(scope, el) {
+                expect(el.outerHTML).toEqual(
+                  '<span attribute="1"></span>'
+                );
+              },
+
+              post: function(scope, el) {
+              }
+            }
+          }
+        }
+      });
+      renderer.register('span', function() {
+        return {
+          priority: 200,
+          compile: function() {
+            return {
+              pre: function(scope, el) {
+                expect(el.outerHTML).toEqual(
+                  '<span attribute="{{ someExpHere || 1 }}"></span>'
+                );
+              }
+            }
+          }
+        }
+      });
+
+      renderer.compile(node)(scope);
+    });
 	});
 
 	describe('Priority', function() {


### PR DESCRIPTION
…ith the compiled value on a pre link, before the watcher is set. for we do not want to get a "{{ someThing }}" on an attribute field on post link. If you want to access the pre interpolated attribute, use a pre link. Also, the test case, ensure that the attribute directive will be executed at priority 100 exactly.